### PR TITLE
Fixed missing namespaces in some Helper classes

### DIFF
--- a/Imagekit.UnitTests/ImageKitTestCasesNonAsync.cs
+++ b/Imagekit.UnitTests/ImageKitTestCasesNonAsync.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using Xunit;
 using Newtonsoft.Json.Linq;
+using Imagekit.Helper;
 
 namespace Imagekit.UnitTests.FileVersion
 {
@@ -752,7 +753,3 @@ namespace Imagekit.UnitTests.FileVersion
         }
     }
 }
-
-
-
-

--- a/Imagekit/Helper/ImagekitBase.cs
+++ b/Imagekit/Helper/ImagekitBase.cs
@@ -8,6 +8,7 @@ namespace Imagekit
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Text.RegularExpressions;
+    using global::Imagekit.Helper;
 
     [ExcludeFromCodeCoverage]
     public abstract partial class BaseImagekit<T>

--- a/Imagekit/Helper/ImagekitParams.cs
+++ b/Imagekit/Helper/ImagekitParams.cs
@@ -4,6 +4,8 @@
 
 namespace Imagekit
 {
+    using global::Imagekit.Helper;
+
     public partial class BaseImagekit<T>
     {
         public T Path(string value)

--- a/Imagekit/Helper/Transformation.cs
+++ b/Imagekit/Helper/Transformation.cs
@@ -7,275 +7,278 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
-public partial class Transformation
+namespace Imagekit.Helper
 {
-    public const string KeyNameRegex = "^\\$[a-zA-Z][a-zA-Z0-9]*$";
-    public const string ChainTransformDelimiter = ":";
-    public const string TransformDelimiter = ",";
-    public const string TransformKeyValueDelimiter = "-";
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Transformation"/> class.
-    /// </summary>
-    /// <param name="transformParams">
-    /// </param>
-    public Transformation(Dictionary<string, object> transformParams)
+    public partial class Transformation
     {
-        foreach (var key in transformParams.Keys)
+        public const string KeyNameRegex = "^\\$[a-zA-Z][a-zA-Z0-9]*$";
+        public const string ChainTransformDelimiter = ":";
+        public const string TransformDelimiter = ",";
+        public const string TransformKeyValueDelimiter = "-";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Transformation"/> class.
+        /// </summary>
+        /// <param name="transformParams">
+        /// </param>
+        public Transformation(Dictionary<string, object> transformParams)
         {
-            transformParams.Add(key, transformParams[key]);
-        }
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Transformation"/> class.
-    /// Creates transformation object initialized with array of transformation parameters.
-    /// </summary>
-    /// <param name="transformParams">List of transformation parameters represented as pairs 'name=value'.</param>
-    public Transformation(params string[] transformParams)
-    {
-        foreach (var pair in transformParams)
-        {
-            string[] splittedPair = pair.Split('=');
-            if (splittedPair.Length != 2)
+            foreach (var key in transformParams.Keys)
             {
-                throw new Exception(string.Format("Couldn't parse '{0}'!", pair));
-            }
-
-            this.Add(splittedPair[0], splittedPair[1]);
-        }
-    }
-
-    /// <summary>
-    /// Add transformation parameter.
-    /// </summary>
-    /// <param name="key">The name.</param>
-    /// <param name="value">The value.</param>
-    public Transformation Add(string key, object value)
-    {
-        if (this.transformParams.ContainsKey(key))
-        {
-            this.transformParams[key] = value;
-        }
-        else
-        {
-            this.transformParams.Add(key, value);
-        }
-
-        return this;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Transformation"/> class.
-    /// Creates empty transformation object.
-    /// </summary>
-    public Transformation()
-    {
-    }
-
-    /// <summary>
-    /// A dictionary of transformation parameters.
-    /// </summary>
-    protected Dictionary<string, object> transformParams = new Dictionary<string, object>();
-
-    /// <summary>
-    /// A list of nested transformations.
-    /// </summary>
-    protected List<Transformation> nestedTransforms = new List<Transformation>();
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Transformation"/> class.
-    /// Creates transformation object chained with other transformations.
-    /// </summary>
-    /// <param name="transforms">List of transformations to chain with.</param>
-    public Transformation(List<Transformation> transforms)
-    {
-        if (transforms != null)
-        {
-            this.nestedTransforms = transforms;
-        }
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Transformation"/> class.
-    /// </summary>
-    /// <param name="dictionary">
-    /// </param>
-    public Transformation(Dictionary<string, object>[] dictionary)
-    {
-        for (int i = 0; i < dictionary.Length; i++)
-        {
-            if (i == dictionary.Length - 1)
-            {
-                this.transformParams = dictionary[i];
-            }
-            else
-            {
-                this.nestedTransforms.Add(new Transformation(dictionary[i]));
-            }
-        }
-    }
-
-    /// <summary>
-    /// Get the transformation parameters dictionary.
-    /// </summary>
-    public Dictionary<string, object> Params
-    {
-        get { return this.transformParams; }
-    }
-
-    /// <summary>
-    /// Get list of nested transformations.
-    /// </summary>
-    public List<Transformation> NestedTransforms
-    {
-        get { return this.nestedTransforms; }
-    }
-
-    /// <summary>
-    /// Chain transformation.
-    /// </summary>
-    public Transformation Chain()
-    {
-        Transformation nested = this.Clone();
-        nested.nestedTransforms = null;
-        this.nestedTransforms.Add(nested);
-        this.transformParams = new Dictionary<string, object>();
-        Transformation transform = new Transformation(this.nestedTransforms);
-        return transform;
-    }
-
-    /// <summary>
-    /// Get a deep cloned copy of this transformation.
-    /// </summary>
-    /// <returns>A deep cloned copy of this transformation.</returns>
-    public Transformation Clone()
-    {
-        Transformation t = (Transformation)this.MemberwiseClone();
-
-        t.transformParams = new Dictionary<string, object>();
-
-        foreach (var key in this.transformParams.Keys)
-        {
-            var value = this.transformParams[key];
-
-            if (value is Array)
-            {
-                t.Add(key, ((Array)value).Clone());
-            }
-            else if (value is string || value is ValueType)
-            {
-                t.Add(key, value);
-            }
-            else if (value is Dictionary<string, string>)
-            {
-                t.Add(key, new Dictionary<string, string>((Dictionary<string, string>)value));
-            }
-            else
-            {
-                throw new Exception(string.Format("Couldn't clone parameter '{0}'!", key));
+                transformParams.Add(key, transformParams[key]);
             }
         }
 
-        if (this.nestedTransforms != null)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Transformation"/> class.
+        /// Creates transformation object initialized with array of transformation parameters.
+        /// </summary>
+        /// <param name="transformParams">List of transformation parameters represented as pairs 'name=value'.</param>
+        public Transformation(params string[] transformParams)
         {
-            t.nestedTransforms = new List<Transformation>();
-            foreach (var nestedTransform in this.nestedTransforms)
+            foreach (var pair in transformParams)
             {
-                t.nestedTransforms.Add(nestedTransform.Clone());
-            }
-        }
-
-        return t;
-    }
-
-    /// <summary>
-    /// Get this transformation represented as string.
-    /// </summary>
-    /// <returns>The transformation represented as string.</returns>
-    public string Generate()
-    {
-        List<string> parts = new List<string>(this.nestedTransforms.Select(t => t.GetTrans()).ToList());
-
-        var thisTransform = this.GetTrans();
-        if (!string.IsNullOrEmpty(thisTransform))
-        {
-            parts.Add(thisTransform);
-        }
-
-        return string.Join(ChainTransformDelimiter, parts.ToArray());
-    }
-
-    public string GetTrans()
-    {
-        List<string> transformations = new List<string>();
-        List<string> varParams = new List<string>();
-
-        foreach (var key in this.transformParams.Keys)
-        {
-            string val = this.GetString(this.transformParams, key);
-            if (string.IsNullOrEmpty(val))
-            {
-                varParams.Add($"{key}");
-            }
-            else
-            {
-                if (key == "oi" || key == "di")
+                string[] splittedPair = pair.Split('=');
+                if (splittedPair.Length != 2)
                 {
-                    val = val.TrimStart('/').TrimEnd('/');
-                    val = val.Replace("/", "@@");
+                    throw new Exception(string.Format("Couldn't parse '{0}'!", pair));
                 }
 
-                varParams.Add($"{key}-{val}");
+                this.Add(splittedPair[0], splittedPair[1]);
             }
         }
 
-        if (varParams.Count > 0)
+        /// <summary>
+        /// Add transformation parameter.
+        /// </summary>
+        /// <param name="key">The name.</param>
+        /// <param name="value">The value.</param>
+        public Transformation Add(string key, object value)
         {
-            transformations.Add(string.Join(TransformDelimiter, varParams));
+            if (this.transformParams.ContainsKey(key))
+            {
+                this.transformParams[key] = value;
+            }
+            else
+            {
+                this.transformParams.Add(key, value);
+            }
+
+            return this;
         }
 
-        return string.Join(ChainTransformDelimiter, transformations.ToArray());
-    }
-
-    private string GetString(Dictionary<string, object> options, string key)
-    {
-        if (options.ContainsKey(key))
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Transformation"/> class.
+        /// Creates empty transformation object.
+        /// </summary>
+        public Transformation()
         {
-            return ToString(options[key]);
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    private static string ToString(object obj)
-    {
-        if (obj == null)
-        {
-            return null;
         }
 
-        if (obj is string)
+        /// <summary>
+        /// A dictionary of transformation parameters.
+        /// </summary>
+        protected Dictionary<string, object> transformParams = new Dictionary<string, object>();
+
+        /// <summary>
+        /// A list of nested transformations.
+        /// </summary>
+        protected List<Transformation> nestedTransforms = new List<Transformation>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Transformation"/> class.
+        /// Creates transformation object chained with other transformations.
+        /// </summary>
+        /// <param name="transforms">List of transformations to chain with.</param>
+        public Transformation(List<Transformation> transforms)
         {
-            return obj.ToString();
+            if (transforms != null)
+            {
+                this.nestedTransforms = transforms;
+            }
         }
 
-        if (obj is float || obj is double)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Transformation"/> class.
+        /// </summary>
+        /// <param name="dictionary">
+        /// </param>
+        public Transformation(Dictionary<string, object>[] dictionary)
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0:0.0#}", obj);
+            for (int i = 0; i < dictionary.Length; i++)
+            {
+                if (i == dictionary.Length - 1)
+                {
+                    this.transformParams = dictionary[i];
+                }
+                else
+                {
+                    this.nestedTransforms.Add(new Transformation(dictionary[i]));
+                }
+            }
         }
 
-        return string.Format(CultureInfo.InvariantCulture, "{0}", obj);
-    }
+        /// <summary>
+        /// Get the transformation parameters dictionary.
+        /// </summary>
+        public Dictionary<string, object> Params
+        {
+            get { return this.transformParams; }
+        }
 
-    /// <summary>
-    /// Get this transformation represented as string.
-    /// </summary>
-    /// <returns>The transformation represented as string.</returns>
-    public override string ToString()
-    {
-        return this.Generate();
+        /// <summary>
+        /// Get list of nested transformations.
+        /// </summary>
+        public List<Transformation> NestedTransforms
+        {
+            get { return this.nestedTransforms; }
+        }
+
+        /// <summary>
+        /// Chain transformation.
+        /// </summary>
+        public Transformation Chain()
+        {
+            Transformation nested = this.Clone();
+            nested.nestedTransforms = null;
+            this.nestedTransforms.Add(nested);
+            this.transformParams = new Dictionary<string, object>();
+            Transformation transform = new Transformation(this.nestedTransforms);
+            return transform;
+        }
+
+        /// <summary>
+        /// Get a deep cloned copy of this transformation.
+        /// </summary>
+        /// <returns>A deep cloned copy of this transformation.</returns>
+        public Transformation Clone()
+        {
+            Transformation t = (Transformation) this.MemberwiseClone();
+
+            t.transformParams = new Dictionary<string, object>();
+
+            foreach (var key in this.transformParams.Keys)
+            {
+                var value = this.transformParams[key];
+
+                if (value is Array)
+                {
+                    t.Add(key, ((Array) value).Clone());
+                }
+                else if (value is string || value is ValueType)
+                {
+                    t.Add(key, value);
+                }
+                else if (value is Dictionary<string, string>)
+                {
+                    t.Add(key, new Dictionary<string, string>((Dictionary<string, string>) value));
+                }
+                else
+                {
+                    throw new Exception(string.Format("Couldn't clone parameter '{0}'!", key));
+                }
+            }
+
+            if (this.nestedTransforms != null)
+            {
+                t.nestedTransforms = new List<Transformation>();
+                foreach (var nestedTransform in this.nestedTransforms)
+                {
+                    t.nestedTransforms.Add(nestedTransform.Clone());
+                }
+            }
+
+            return t;
+        }
+
+        /// <summary>
+        /// Get this transformation represented as string.
+        /// </summary>
+        /// <returns>The transformation represented as string.</returns>
+        public string Generate()
+        {
+            List<string> parts = new List<string>(this.nestedTransforms.Select(t => t.GetTrans()).ToList());
+
+            var thisTransform = this.GetTrans();
+            if (!string.IsNullOrEmpty(thisTransform))
+            {
+                parts.Add(thisTransform);
+            }
+
+            return string.Join(ChainTransformDelimiter, parts.ToArray());
+        }
+
+        public string GetTrans()
+        {
+            List<string> transformations = new List<string>();
+            List<string> varParams = new List<string>();
+
+            foreach (var key in this.transformParams.Keys)
+            {
+                string val = this.GetString(this.transformParams, key);
+                if (string.IsNullOrEmpty(val))
+                {
+                    varParams.Add($"{key}");
+                }
+                else
+                {
+                    if (key == "oi" || key == "di")
+                    {
+                        val = val.TrimStart('/').TrimEnd('/');
+                        val = val.Replace("/", "@@");
+                    }
+
+                    varParams.Add($"{key}-{val}");
+                }
+            }
+
+            if (varParams.Count > 0)
+            {
+                transformations.Add(string.Join(TransformDelimiter, varParams));
+            }
+
+            return string.Join(ChainTransformDelimiter, transformations.ToArray());
+        }
+
+        private string GetString(Dictionary<string, object> options, string key)
+        {
+            if (options.ContainsKey(key))
+            {
+                return ToString(options[key]);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private static string ToString(object obj)
+        {
+            if (obj == null)
+            {
+                return null;
+            }
+
+            if (obj is string)
+            {
+                return obj.ToString();
+            }
+
+            if (obj is float || obj is double)
+            {
+                return string.Format(CultureInfo.InvariantCulture, "{0:0.0#}", obj);
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, "{0}", obj);
+        }
+
+        /// <summary>
+        /// Get this transformation represented as string.
+        /// </summary>
+        /// <returns>The transformation represented as string.</returns>
+        public override string ToString()
+        {
+            return this.Generate();
+        }
     }
 }

--- a/Imagekit/Helper/TransformationTypes.cs
+++ b/Imagekit/Helper/TransformationTypes.cs
@@ -5,427 +5,430 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-[ExcludeFromCodeCoverage]
-public partial class Transformation
+namespace Imagekit.Helper
 {
-    /// <summary>Width of a transformed image</summary>
-    /// <param name="value"></param>
-    public Transformation Width(int value)
+    [ExcludeFromCodeCoverage]
+    public partial class Transformation
     {
-        return this.Add("w", value);
-    }
+        /// <summary>Width of a transformed image</summary>
+        /// <param name="value"></param>
+        public Transformation Width(int value)
+        {
+            return this.Add("w", value);
+        }
 
-    /// <summary>Height of a transformed image</summary>
-    /// <param name="value"></param>
-    public Transformation Height(int value)
-    {
-        return this.Add("h", value);
-    }
+        /// <summary>Height of a transformed image</summary>
+        /// <param name="value"></param>
+        public Transformation Height(int value)
+        {
+            return this.Add("h", value);
+        }
 
-    /// <summary>Aspect Ratio of a transformed image</summary>
-    /// <param name="value"></param>
-    public Transformation AspectRatio(string value)
-    {
-        return this.Add("ar", value);
-    }
+        /// <summary>Aspect Ratio of a transformed image</summary>
+        /// <param name="value"></param>
+        public Transformation AspectRatio(string value)
+        {
+            return this.Add("ar", value);
+        }
 
-    /// <summary>
-    /// JPG compression quality. 1 is the lowest quality and 100 is the highest. The default is the
-    /// original image's quality or 80% if not available.
-    /// </summary>
-    /// <param name="value"></param>
-    public Transformation Quality(int value)
-    {
-        return this.Add("q", value);
-    }
+        /// <summary>
+        /// JPG compression quality. 1 is the lowest quality and 100 is the highest. The default is the
+        /// original image's quality or 80% if not available.
+        /// </summary>
+        /// <param name="value"></param>
+        public Transformation Quality(int value)
+        {
+            return this.Add("q", value);
+        }
 
-    /// <summary>Crop Transformation.</summary>
-    /// <param name="value"></param>
-    public Transformation Crop(string value)
-    {
-        return this.Add("c", value);
-    }
+        /// <summary>Crop Transformation.</summary>
+        /// <param name="value"></param>
+        public Transformation Crop(string value)
+        {
+            return this.Add("c", value);
+        }
 
-    /// <summary>Crop Mode</summary>
-    /// <param name="value"></param>
-    public Transformation CropMode(string value)
-    {
-        return this.Add("cm", value);
-    }
+        /// <summary>Crop Mode</summary>
+        /// <param name="value"></param>
+        public Transformation CropMode(string value)
+        {
+            return this.Add("cm", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation X(int value)
-    {
-        return this.Add("x", this.ConvertCoordinateParam(value));
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation X(int value)
+        {
+            return this.Add("x", this.ConvertCoordinateParam(value));
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Y(int value)
-    {
-        return this.Add("y", this.ConvertCoordinateParam(value));
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Y(int value)
+        {
+            return this.Add("y", this.ConvertCoordinateParam(value));
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Focus(string value)
-    {
-        return this.Add("fo", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Focus(string value)
+        {
+            return this.Add("fo", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Format(string value)
-    {
-        return this.Add("f", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Format(string value)
+        {
+            return this.Add("f", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Radius(object value)
-    {
-        return this.Add("r", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Radius(object value)
+        {
+            return this.Add("r", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Background(string value)
-    {
-        return this.Add("bg", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Background(string value)
+        {
+            return this.Add("bg", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Border(string value)
-    {
-        return this.Add("b", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Border(string value)
+        {
+            return this.Add("b", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Rotation(object value)
-    {
-        return this.Add("rt", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Rotation(object value)
+        {
+            return this.Add("rt", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Rotate(object value)
-    {
-        return this.Add("rt", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Rotate(object value)
+        {
+            return this.Add("rt", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Blur(int value)
-    {
-        return this.Add("bl", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Blur(int value)
+        {
+            return this.Add("bl", value);
+        }
 
-    /// <summary>Add named transformation.</summary>
-    /// <param name="value">named transformation.</param>
-    public Transformation Named(string value)
-    {
-        return this.Add("n", value);
-    }
+        /// <summary>Add named transformation.</summary>
+        /// <param name="value">named transformation.</param>
+        public Transformation Named(string value)
+        {
+            return this.Add("n", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayImage(string value)
-    {
-        return this.Add("oi", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayImage(string value)
+        {
+            return this.Add("oi", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayX(int value)
-    {
-        return this.Add("ox", this.ConvertCoordinateParam(value));
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayX(int value)
+        {
+            return this.Add("ox", this.ConvertCoordinateParam(value));
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayY(int value)
-    {
-        return this.Add("oy", this.ConvertCoordinateParam(value));
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayY(int value)
+        {
+            return this.Add("oy", this.ConvertCoordinateParam(value));
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayFocus(string value)
-    {
-        return this.Add("ofo", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayFocus(string value)
+        {
+            return this.Add("ofo", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayHeight(int value)
-    {
-        return this.Add("oh", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayHeight(int value)
+        {
+            return this.Add("oh", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayWidth(int value)
-    {
-        return this.Add("ow", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayWidth(int value)
+        {
+            return this.Add("ow", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayText(string value)
-    {
-        return this.Add("ot", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayText(string value)
+        {
+            return this.Add("ot", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextFontSize(int value)
-    {
-        return this.Add("ots", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextFontSize(int value)
+        {
+            return this.Add("ots", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextFontFamily(string value)
-    {
-        return this.Add("otf", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextFontFamily(string value)
+        {
+            return this.Add("otf", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextColor(string value)
-    {
-        return this.Add("otc", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextColor(string value)
+        {
+            return this.Add("otc", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverylayAlpha(int value)
-    {
-        return this.Add("oa", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverylayAlpha(int value)
+        {
+            return this.Add("oa", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextTypography(string value)
-    {
-        return this.Add("ott", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextTypography(string value)
+        {
+            return this.Add("ott", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextTransparency(int value)
-    {
-        return this.Add("oa", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextTransparency(int value)
+        {
+            return this.Add("oa", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextBackground(string value)
-    {
-        return this.Add("otbg", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextBackground(string value)
+        {
+            return this.Add("otbg", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextEncoded(string value)
-    {
-        return this.Add("ote", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextEncoded(string value)
+        {
+            return this.Add("ote", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextWidth(int value)
-    {
-        return this.Add("otw", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextWidth(int value)
+        {
+            return this.Add("otw", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextPadding(int value)
-    {
-        return this.Add("otp", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextPadding(int value)
+        {
+            return this.Add("otp", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayTextInnerAlignment(string value)
-    {
-        return this.Add("otia", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayTextInnerAlignment(string value)
+        {
+            return this.Add("otia", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayRadius(int value)
-    {
-        return this.Add("or", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayRadius(int value)
+        {
+            return this.Add("or", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayBackground(string value)
-    {
-        return this.Add("obg", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayBackground(string value)
+        {
+            return this.Add("obg", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayImageTrim(bool value)
-    {
-        return this.Add("oit", value.ToString().ToLower());
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayImageTrim(bool value)
+        {
+            return this.Add("oit", value.ToString().ToLower());
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayImageAspectRatio(string value)
-    {
-        return this.Add("oiar", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayImageAspectRatio(string value)
+        {
+            return this.Add("oiar", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayImageBackground(string value)
-    {
-        return this.Add("oibg", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayImageBackground(string value)
+        {
+            return this.Add("oibg", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayImageBorder(string value)
-    {
-        return this.Add("oib", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayImageBorder(string value)
+        {
+            return this.Add("oib", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayImageDpr(object value)
-    {
-        return this.Add("oidpr", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayImageDpr(object value)
+        {
+            return this.Add("oidpr", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayImageQuality(int value)
-    {
-        return this.Add("oiq", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayImageQuality(int value)
+        {
+            return this.Add("oiq", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation OverlayImageCropping(string value)
-    {
-        return this.Add("oic", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation OverlayImageCropping(string value)
+        {
+            return this.Add("oic", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Progressive(bool value)
-    {
-        return this.Add("pr", value.ToString().ToLower());
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Progressive(bool value)
+        {
+            return this.Add("pr", value.ToString().ToLower());
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Lossless(bool value)
-    {
-        return this.Add("lo", value.ToString().ToLower());
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Lossless(bool value)
+        {
+            return this.Add("lo", value.ToString().ToLower());
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Trim(int value)
-    {
-        return this.Add("t", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Trim(int value)
+        {
+            return this.Add("t", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Metadata(bool value)
-    {
-        return this.Add("md", value.ToString().ToLower());
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Metadata(bool value)
+        {
+            return this.Add("md", value.ToString().ToLower());
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation ColorProfile(bool value)
-    {
-        return this.Add("cp", value.ToString().ToLower());
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation ColorProfile(bool value)
+        {
+            return this.Add("cp", value.ToString().ToLower());
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation DefaultImage(string value)
-    {
-        return this.Add("di", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation DefaultImage(string value)
+        {
+            return this.Add("di", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation Dpr(object value)
-    {
-        return this.Add("dpr", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation Dpr(object value)
+        {
+            return this.Add("dpr", value);
+        }
 
-    /// <summary></summary>
-    public Transformation EffectSharpen()
-    {
-        return this.Add("e-sharpen", string.Empty);
-    }
+        /// <summary></summary>
+        public Transformation EffectSharpen()
+        {
+            return this.Add("e-sharpen", string.Empty);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation EffectSharpen(int value)
-    {
-        return this.Add("e-sharpen", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation EffectSharpen(int value)
+        {
+            return this.Add("e-sharpen", value);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation EffectUsm(string value)
-    {
-        return this.Add("e-usm", value);
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation EffectUsm(string value)
+        {
+            return this.Add("e-usm", value);
+        }
 
-    /// <summary></summary>
-    public Transformation EffectContrast()
-    {
-        return this.Add("e-contrast", string.Empty);
-    }
+        /// <summary></summary>
+        public Transformation EffectContrast()
+        {
+            return this.Add("e-contrast", string.Empty);
+        }
 
-    /// <summary></summary>
-    /// <param name="value"></param>
-    public Transformation EffectContrast(object value)
-    {
-        return this.Add("e-contrast", value.ToString().ToLower());
-    }
+        /// <summary></summary>
+        /// <param name="value"></param>
+        public Transformation EffectContrast(object value)
+        {
+            return this.Add("e-contrast", value.ToString().ToLower());
+        }
 
-    /// <summary></summary>
-    public Transformation EffectGray()
-    {
-        return this.Add("e-grayscale", "true");
-    }
+        /// <summary></summary>
+        public Transformation EffectGray()
+        {
+            return this.Add("e-grayscale", "true");
+        }
 
-    /// <summary></summary>
-    public Transformation Original()
-    {
-        return this.Add("orig", "true");
-    }
+        /// <summary></summary>
+        public Transformation Original()
+        {
+            return this.Add("orig", "true");
+        }
 
-    /// <summary>
-    /// Pass an raw transformation string (including chained transformations)
-    /// </summary>
-    /// <param name="value">A raw transformation string.</param>
-    public Transformation Raw(string value)
-    {
-        return this.Add(value, string.Empty);
-    }
+        /// <summary>
+        /// Pass an raw transformation string (including chained transformations)
+        /// </summary>
+        /// <param name="value">A raw transformation string.</param>
+        public Transformation Raw(string value)
+        {
+            return this.Add(value, string.Empty);
+        }
 
-    private string ConvertCoordinateParam(int paramValue)
-    {
-        return paramValue < 0
-            ? $"N{Math.Abs(paramValue)}"
-            : $"{paramValue}";
+        private string ConvertCoordinateParam(int paramValue)
+        {
+            return paramValue < 0
+                ? $"N{Math.Abs(paramValue)}"
+                : $"{paramValue}";
+        }
     }
 }


### PR DESCRIPTION
## Fix
I fixed issue #57 by adding `namespace Imagekit.Helper` to `Url.cs`, `Transformation.cs` and `TransformationTypes.cs`.

I also added any necessary `using` statements where needed and followed your pattern of putting using statements inside the namespace with `global::` where needed.

`Url.cs`, `Transformation.cs` and `TransformationTypes.cs` were also slightly reformatted automatically by my IDE, but it doesn't seem like there were any meaningful changes, mostly just indentation to account for the added namespace.

## Testing
I built the project to make sure it compiles correctly and ran all the unit tests. All unit tests passed on the dotnet versions I had installed.

Note that I didn't have all the dotnet versions that the unit tests use installed, but given the minimal changes I am pretty confident the tests would pass on those versions of dotnet too.