### PR TITLE
fixed wrong type name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add this reference where you want to use imagekit.io services:
 ```cs
 using Imagekit;
 
-ImageKitClient imagekit = new ImageKitClient(publicKey, privateKey, urlEndPoint);
+ImagekitClient imagekit = new ImagekitClient(publicKey, privateKey, urlEndPoint);
 ```
 
 **Note**: You can get the `apiKey`, `apiSecret`, and ImagekitId from your [Imagekit.io dashboard](https://imagekit.io/dashboard).


### PR DESCRIPTION
It seems like Image**K**itClient class name changed to Image**k**itClient ('...kit...' lower case) with latest version.

![image](https://github.com/imagekit-developer/imagekit-dotnet/assets/49621993/04eece5b-1b85-4ffa-95c3-952efa02868c)

